### PR TITLE
Add in SSH agent test and link

### DIFF
--- a/source/ansible.rst
+++ b/source/ansible.rst
@@ -9,8 +9,16 @@ Final configuration step
 ------------------------
 
 You can log into the management node at ``yourusername@mgmtipaddress``,
-using the IP address that terraform printed at the endo of its run.
-For example:
+using the IP address that terraform printed at the end of its run. You can `forward
+your SSH key <https://developer.github.com/v3/guides/using-ssh-agent-forwarding/>`_
+from your workstation to avoid copying the private key in to the cloud. First test 
+that you can talk to the SSH agent by asking it to list the keys:
+
+.. code-block:: shell-session
+
+   $ ssh-add -L
+
+Then connect to the managment node. For example:
 
 .. code-block:: shell-session
 


### PR DESCRIPTION
We have had feedback that some people are getting errors when running the Ansible bit of the finish script. If the SSH agent isn't started there will be difficulty connecting to the other nodes. This patch adds in a test that users can run and links to the GitHub documentation in agent forwarding.