### PR TITLE
Add instructions on setting up GPU nodes on AWS

### DIFF
--- a/source/running.rst
+++ b/source/running.rst
@@ -149,7 +149,7 @@ following to the end of the ``source "amazon-ebs" "aws"`` section
 
    launch_block_device_mappings {
        device_name = "/dev/sda1"
-       volume_size =  40
+       volume_size =  10
    }
 
 We can now re-build the image used to provision compute nodes:

--- a/source/running.rst
+++ b/source/running.rst
@@ -135,7 +135,6 @@ install the nvidia driver and CUDA toolchain:
    sudo dnf clean all
    sudo dnf -y install kernel-devel
    sudo dnf -y module install nvidia-driver:latest-dkms
-   sudo dnf -y install cuda
    sudo dkms autoinstall
    EOF
 

--- a/source/running.rst
+++ b/source/running.rst
@@ -138,19 +138,6 @@ install the nvidia driver and CUDA toolchain:
    sudo dkms autoinstall
    EOF
 
-We can't just rebuild our image straight away though since the CUDA
-toolchain is large and exceeds the base image size, consequently we need
-to change the packer configuration to create a larger image. Edit
-``/etc/citc/packer/all.pkr.hcl`` in your favourite editor, and add the
-following to the end of the ``source "amazon-ebs" "aws"`` section
-
-.. code-block:: 
-
-   launch_block_device_mappings {
-       device_name = "/dev/sda1"
-       volume_size =  10
-   }
-
 We can now re-build the image used to provision compute nodes:
 
 .. code-block:: shell-session


### PR DESCRIPTION
This PR brings in instructions for users to set up an AMI with the necessary drivers and toolchain for running CUDA applications on AWS.